### PR TITLE
Close output file

### DIFF
--- a/flake8_sarif_formatter/flake8_sarif_formatter.py
+++ b/flake8_sarif_formatter/flake8_sarif_formatter.py
@@ -66,6 +66,8 @@ class SarifFormatter(base.BaseFormatter):
 
         json.dump(sarif, self.output_fd if self.output_fd is not None else sys.stdout, indent=2)
 
+        super().stop()
+
     def handle(self, error: Violation):
         """Convert the error into a SARIF result, and append it to the SARIF."""
         rule_id = f"flake8/{error.code}"


### PR DESCRIPTION
Call `.stop()` from the parent class.

`BaseFormatter.stop()` closes the output file: https://github.com/PyCQA/flake8/blob/23e4005c5501999c29e1e3774de7ed18d1e4e22d/src/flake8/formatting/base.py#L201

If the output file is not closed explicitly, flake8 creates an empty (invalid) output file.