### PR TITLE
Potential fix for code scanning alert no. 36: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -1,4 +1,6 @@
 name: Python Lint Workflow
+permissions:
+  contents: read
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/python_lint.yml
+++ b/.github/workflows/python_lint.yml
@@ -1,6 +1,4 @@
 name: Python Lint Workflow
-permissions:
-  contents: read
 on:
   push:
     branches: [ "main" ]
@@ -10,6 +8,9 @@ on:
   schedule:
     - cron: '22 3 * * 4'
   workflow_dispatch:
+permissions:
+  contents: read
+  security-events: write
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/advanced-security/flake8-sarif-formatter/security/code-scanning/36](https://github.com/advanced-security/flake8-sarif-formatter/security/code-scanning/36)

To fix the problem, add a `permissions` block at the workflow or job level to restrict the permissions granted to the GITHUB_TOKEN. Since the job does not appear to require any write or privileged access, set `contents: read` either at the root (applies to all jobs), or directly in the `lint` job. The best (simplest and most future-proof) fix is to add the following block at the top level, directly below the `name`, before `on`, so that it applies to the entire workflow. This keeps the permission restriction explicit and maintainable.

No additional methods, imports, or changes are required — simply insert the YAML `permissions:` block:

```yaml
permissions:
  contents: read
```


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
