### PR TITLE
fix: correct dependabot.yml schema

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,8 @@ updates:
     groups:
       all-actions:
         patterns: ["*"]
-    default-days: 7
-
+    cooldown:
+      default-days: 7
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -17,4 +17,5 @@ updates:
       all-python:
         patterns: ["*"]
     versioning-strategy: lockfile-only
-    default-days: 7
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Fixes schema errors introduced in #10:
- Move \default-days\ under \cooldown:\ parent (required by Dependabot schema)
